### PR TITLE
fix falsey values usage errors from uri_escape

### DIFF
--- a/lib/HTTP/AnyUA/Util.pm
+++ b/lib/HTTP/AnyUA/Util.pm
@@ -257,7 +257,10 @@ $escapes{' '} = '+';
 my $unsafe_char = qr/[^A-Za-z0-9\-\._~]/;
 
 sub uri_escape {
-    my $str = shift or _usage(q{uri_escape($str)});
+    my $str = shift;
+
+    _usage(q{uri_escape($str)}) unless defined $str;
+
     if ($] ge '5.008') {
         utf8::encode($str);
     }


### PR DESCRIPTION
In December, WebService::Slack::WebApi switched to requiring HTTP::AnyUA rather than Furl,
and when it did I noticed that fields with falsey boolean values (zero) started throwing these
usage errors. This change resolved it for me, though URI::Escape->uri_escape itself currently
does:

`return undef unless defined $text;`

So maybe that's more appropriate here as well, but regardless, the defined check rather
than truthy check being the real focus to allow falsey values.